### PR TITLE
README.md - remove outdated download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ A [NeosModLoader](https://github.com/zkxs/NeosModLoader) mod for [Neos VR](https
 
 ## Installation
 1. Install [NeosModLoader](https://github.com/zkxs/NeosModLoader).
-1. Place [IKCulling.dll](https://github.com/KyuubiYoru/IkCulling/releases/latest/download/IKCulling.dll) into your `nml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods` for a default install. You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
+1. Compile the project and place IKCulling.dll into your `nml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods` for a default install. You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
 1. Start the game. If you want to verify that the mod is working you can check your Neos logs.


### PR DESCRIPTION
README.md still has a link to the DLL of the archived version of this mod, despite having made improvements to it since then. It seems that this repository does not provide downloadable DLL files, so there's nothing meaningful to link here.